### PR TITLE
Add basic tests and docs for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ The script includes error handling for:
 
 Before embedding metadata, the script creates a backup of the original image by appending `.original` to the filename.
 
+### Running Tests
+
+After installing the requirements, you can execute the unit tests using `pytest` from the repository root:
+
+```bash
+pytest
+```
+
 ### License
 
 This project is licensed under the MIT License. See the LICENSE file for details.

--- a/tests/test_image_eval_embed.py
+++ b/tests/test_image_eval_embed.py
@@ -1,0 +1,24 @@
+import sys
+import os
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from image_eval_embed import sanitize_string, Metadata
+
+
+def test_sanitize_string_removes_null_and_newlines():
+    raw = "Hello\x00World\nNew\rLine"
+    result = sanitize_string(raw)
+    assert "\x00" not in result
+    assert "\n" not in result
+    assert "\r" not in result
+    assert result == "HelloWorld New Line"
+
+
+def test_metadata_keywords_truncated_to_twelve():
+    keywords = ",".join(f"kw{i}" for i in range(15))
+    md = Metadata(score=1, title="t", description="d", keywords=keywords)
+    result_keywords = md.keywords.split(',')
+    assert len(result_keywords) == 12
+    assert result_keywords == [f"kw{i}" for i in range(12)]


### PR DESCRIPTION
## Summary
- add unit tests covering sanitize_string and keyword truncation
- document how to run the pytest suite

## Testing
- `pip install -r requirements.txt`
- `pip install --upgrade 'pydantic>=2'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d787c363c832ab119af73fe5f1993